### PR TITLE
Show invitation URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Shell
 
+## 25.1.9
+
+- Display invitation URL if available (!10)
+
 ## 25.1.8
 
 - Make auth header username displayal more defensive (!7)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_shell",
-	"version": "25.1.8",
+	"version": "25.1.9",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Shell Application",
 	"contributors": [

--- a/src/modules/auth/screens/InvitationScreen.js
+++ b/src/modules/auth/screens/InvitationScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { ResultCard } from 'asab_webui_components';
@@ -23,18 +23,6 @@ export default function InvitationScreen(props) {
 	const navigate = useNavigate();
 	const SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
 
-	// Time out the visual effects of copying URL
-	useEffect(() => {
-		let timeoutId;
-		if (urlCopied) {
-			timeoutId = setTimeout(() => setUrlCopied(false), 3000);
-		}
-
-		return () => {
-			clearTimeout(timeoutId);
-		};
-	}, [urlCopied]);
-
 	// Copy registration URL if there is any
 	const copyRegistrationUrl = () => {
 		if (!registrationUrl) {
@@ -45,6 +33,10 @@ export default function InvitationScreen(props) {
 		navigator.clipboard.writeText(registrationUrl)
 			.then(() => {
 				setUrlCopied(true);
+				let timeoutId = setTimeout(() => setUrlCopied(false), 3000);
+				return () => {
+					clearTimeout(timeoutId);
+				};
 			})
 			.catch((error) => {
 				console.error('Failed to copy registration URL: ', error);
@@ -91,17 +83,16 @@ export default function InvitationScreen(props) {
 			<FormText>
 				{t('InvitationScreen|If you want to invite the user manually, message them the registration URL below:')}
 			</FormText>
-			<InputGroup
-				onClick={copyRegistrationUrl}
-			>
+			<InputGroup>
 				<Input 
-					disabled
+					readOnly
 					value={registrationUrl}
 				/>
 				<Button
 					outline
-					color={urlCopied ? 'success' : 'primary'}
+					color='primary'
 					className='w-25'
+					onClick={copyRegistrationUrl}
 				>
 					<i
 						className={urlCopied ? 'bi bi-clipboard-check pe-2' : 'bi bi-clipboard pe-2'}

--- a/src/modules/auth/screens/InvitationScreen.js
+++ b/src/modules/auth/screens/InvitationScreen.js
@@ -91,7 +91,7 @@ export default function InvitationScreen(props) {
 				<Button
 					outline
 					color='primary'
-					className='w-25'
+					className='text-nowrap'
 					onClick={copyRegistrationUrl}
 				>
 					<i
@@ -198,7 +198,7 @@ export default function InvitationScreen(props) {
 										color='primary'
 										disabled={emailValue === ''} // Disable button if input is empty
 									>
-										{t('InvitationScreen|Send')}
+										{t('InvitationScreen|Invite')}
 									</Button>
 								</CardFooter>
 							</Card>

--- a/src/modules/auth/screens/InvitationScreen.js
+++ b/src/modules/auth/screens/InvitationScreen.js
@@ -23,10 +23,11 @@ export default function InvitationScreen(props) {
 	const navigate = useNavigate();
 	const SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
 
+	// Time out the visual effects of copying URL
 	useEffect(() => {
 		let timeoutId;
 		if (urlCopied) {
-			timeoutId = setTimeout(() => setUrlCopied(false), 5000);
+			timeoutId = setTimeout(() => setUrlCopied(false), 3000);
 		}
 
 		return () => {
@@ -34,13 +35,19 @@ export default function InvitationScreen(props) {
 		};
 	}, [urlCopied]);
 
+	// Copy registration URL if there is any
 	const copyRegistrationUrl = () => {
+		if (!registrationUrl) {
+			console.error('No registration URL to copy.');
+			return
+		}
+
 		navigator.clipboard.writeText(registrationUrl)
 			.then(() => {
 				setUrlCopied(true);
 			})
 			.catch((error) => {
-				console.error('Failed to copy text: ', error);
+				console.error('Failed to copy registration URL: ', error);
 			});
 	};
 
@@ -78,29 +85,41 @@ export default function InvitationScreen(props) {
 		}
 	}
 
-	const CopyableRegistrationUrl = ({ registrationUrl, ...childProps }) => (
-		<div {...childProps}>
-			<div>{t('InvitationScreen|If you want to invite the user manually, message them the registration URL below:')}</div>
-			<InputGroup onClick={copyRegistrationUrl}>
+	// Component that displays the registration URL with a copy button
+	const CopyableRegistrationUrl = ({ registrationUrl }) => (
+		<>
+			<FormText>
+				{t('InvitationScreen|If you want to invite the user manually, message them the registration URL below:')}
+			</FormText>
+			<InputGroup
+				onClick={copyRegistrationUrl}
+			>
 				<Input 
 					disabled
 					value={registrationUrl}
 				/>
-				<Button outline color={urlCopied ? 'success' : 'primary'}>
+				<Button
+					outline
+					color={urlCopied ? 'success' : 'primary'}
+					className='w-25'
+				>
 					<i
 						className={urlCopied ? 'bi bi-clipboard-check pe-2' : 'bi bi-clipboard pe-2'}
-						title={t('InvitationScreen|Copy URL to clipboard')}
+						title={t('InvitationScreen|Copy to clipboard')}
 					/>
-					{urlCopied ? t('InvitationScreen|URL copied!') : t('Copy URL')}
+					{urlCopied
+						? t('InvitationScreen|Copied!')
+						: t('InvitationScreen|Copy URL')
+					}
 				</Button>
 			</InputGroup>
-		</div>
+		</>
 	);
 
 	// Display for successful invitation
 	const SuccessfulInvitationCardBody = () => (
 		<>
-			<h6>{t('InvitationScreen|Invitation has been sent successfully')}</h6>
+			<h6>{t('InvitationScreen|Invitation was sent successfully')}</h6>
 			{registrationUrl && <CopyableRegistrationUrl
 				registrationUrl={registrationUrl}
 			/>}
@@ -119,11 +138,10 @@ export default function InvitationScreen(props) {
 	// Display for unsuccessful invitation
 	const UnsuccessfulInvitationCardBody = () => (
 		<>
-			<h6>{t('InvitationScreen|Invitation has not been sent')}</h6>
+			<h6>{t('InvitationScreen|Invitation was not sent')}</h6>
 			{registrationUrl
 				? <CopyableRegistrationUrl
 					registrationUrl={registrationUrl}
-					className='py-3'
 				/>
 				: <FormText>{t('InvitationScreen|The user could not be invited')}</FormText>
 			}
@@ -160,7 +178,7 @@ export default function InvitationScreen(props) {
 									</div>
 								</CardHeader>
 								<CardBody>
-									<Label>{t('InvitationScreen|Enter the email to invite a user')}</Label>
+									<Label>{t('InvitationScreen|Enter the user\'s email address')}</Label>
 									<InputGroup>
 										<InputGroupText>
 											<i className='bi bi-envelope-at' />


### PR DESCRIPTION
# Summary

When the backend sends `registration_url` in the invitation response (usually when requested by superuser), the UI displays it together with a copy button.

# Preview

## Successful invitation
![image](https://github.com/user-attachments/assets/9e638bc9-7fa2-44cd-aecd-15c0a1718f2e)

## Failed invitation
![image](https://github.com/user-attachments/assets/0d2bb8bc-3510-432c-8ae6-0e652daf4c4e)
