### PR TITLE
Add parsing for error.response.data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Shell
 
+## 25.1.12
+
+- Upgrade parsing for error.response.data (!11)
+
 ## 25.1.11
 
 - Upgrade axios peer dependency to `^1.8.4` (!9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 25.1.12
 
-- Upgrade parsing for error.response.data (!11)
+- Added parsing for `error.response.data` in `axios.interceptors` if `content-type: application/json` (!11)
 
 ## 25.1.11
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_shell",
-	"version": "25.1.11",
+	"version": "25.1.12",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Shell Application",
 	"contributors": [

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -364,8 +364,8 @@ class Application extends Component {
 			return response;
 		}, function (error) {
 			that.popNetworkingIndicator();
-
 			const contentType = error?.response?.headers?.['content-type'];
+			// Check if the response content type is 'application/json' and data is a string
 			if (contentType?.startsWith('application/json') && (typeof error.response.data === 'string')) {
 				try {
 					error.response.data = JSON.parse(error.response.data);

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -364,6 +364,16 @@ class Application extends Component {
 			return response;
 		}, function (error) {
 			that.popNetworkingIndicator();
+
+			const contentType = error?.response?.headers?.['content-type'];
+			if (contentType?.startsWith('application/json') && (typeof error.response.data === 'string')) {
+				try {
+					error.response.data = JSON.parse(error.response.data);
+				} catch (e) {
+					console.error("Error parsing error of the error body:", e);
+				}
+			}
+
 			return Promise.reject(error);
 		});
 

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -366,7 +366,7 @@ class Application extends Component {
 			that.popNetworkingIndicator();
 			const contentType = error?.response?.headers?.['content-type'];
 			// Check if the response content type is 'application/json' and data is a string
-			if (contentType?.startsWith('application/json') && (typeof error.response.data === 'string')) {
+			if (contentType?.startsWith('application/json') && (typeof error?.response?.data === 'string')) {
 				try {
 					error.response.data = JSON.parse(error.response.data);
 				} catch (e) {


### PR DESCRIPTION
Since in some places in our applications we process the error body and take data from there, we need to add data parsing since `e.response.data` comes as a string.