### PR TITLE
Extension of condition for bigint processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Shell
 
+## 25.1.12
+
+- Extension of the condition for bigint handling, do not turn numbers not exceeding the limits into bigint numbers (!12)
+
 ## 25.1.11
 
 - Upgrade axios peer dependency to `^1.8.4` (!9)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_shell",
-	"version": "25.1.11",
+	"version": "25.1.12",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Shell Application",
 	"contributors": [

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -347,7 +347,7 @@ class Application extends Component {
 								return value
 							}
 							// Check if the key is in the `JSONParseBigInt` set and the value is a number
-							if (that.JSONParseBigInt.has(key) && (typeof value === 'number')) {
+							if (that.JSONParseBigInt.has(key) && (typeof value === 'number') && (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER)) {
 								// Convert the number to a BigInt
 								return BigInt(context.source);
 							}


### PR DESCRIPTION

I've expanded the condition there where we process bigint. I **noticed** that if we have a type specified in **bootstrap** and it is for example only 1 (e.g. `cnt: 1`). Then our handler in `axios.interceptors` turns it into bigint (`cnt: 1n`) and it is not displayed on UI on Discover screen. To do this, I added a condition. If the value does not exceed the lower and upper limits `(value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER)`, then just do not convert it to bigint.
```
bigint={[
	// bigint prop used by asab-webui-shell-lib for having a set of the keys, where expect the BigInt numbers
	// actual fields can be found here http://gitlab.teskalabs.int/lmio/lmio-common-library/-/blob/master/Schemas/CEF.yaml?ref_type=heads
	...
	'src', 'agentTranslatedZoneKey', 'agentZoneKey', 'cn1', 'cn2', 'cn3', 'cnt', 'customerKey',
	'dTranslatedZoneKey', 'dZoneKey', 'deviceTranslatedZoneKey', 'deviceZoneKey', 'dpid',
	'dvcpid', 'eventId', 'fsize', 'in', 'oldFileSize', 'out', 'sTranslatedZoneKey', 'sZoneKey', 'spid'
]}
```