### PR TITLE
Fix global styling for monaco hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG for ASAB WebUI Shell
 
+## 25.2.5
+
+- Fix on global monaco hover styling, which was compromised by change in order of styles loading due to moving the styles from ASAB Components to ASAB Shell here #16 (#19)
+
 ## 25.2.4
 
-- Updated import for isAuthorized from `asab_webui_components` to `asab_webui_components/seacat-auth` (!13)
+- Updated import for isAuthorized from `asab_webui_components` to `asab_webui_components/seacat-auth` (#13)
 
 ## 25.2.3
 
@@ -18,7 +22,7 @@
 
 ## 25.1.12
 
-- Added parsing for `error.response.data` in `axios.interceptors` if `content-type: application/json` (!11)
+- Added parsing for `error.response.data` in `axios.interceptors` if `content-type: application/json` (#11)
 
 ## 25.1.11
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_shell",
-	"version": "25.2.4",
+	"version": "25.2.5",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Shell Application",
 	"contributors": [

--- a/src/styles/constants/index.scss
+++ b/src/styles/constants/index.scss
@@ -66,5 +66,5 @@
 
 /*Fix the position of the monaco hover marker tooltip*/
 .monaco-hover {
-	position: fixed;
+	position: fixed !important;
 }


### PR DESCRIPTION
- fix global styling for monaco editor hover action which was compromised by change of loading of the global styling due to moving the styles from components to shell