### PR TITLE
Create global (generic) styling for the tabs

### DIFF
--- a/src/styles/components/tabs.scss
+++ b/src/styles/components/tabs.scss
@@ -1,0 +1,15 @@
+.panel-tab {
+    max-width: 20ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+   &.active {
+
+   }
+
+  &:hover {
+    cursor: pointer;
+  }
+}
+

--- a/src/styles/components/tabs.scss
+++ b/src/styles/components/tabs.scss
@@ -1,15 +1,28 @@
+.panel-tab-container {
+  display: flex;
+  align-items: center; /* Align items vertically */
+}
+
 .panel-tab {
     max-width: 20ch;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 
-   &.active {
-
-   }
-
   &:hover {
     cursor: pointer;
   }
+
 }
 
+.panel-tabs-flex-wrapper {
+  /* Ensures horizontally scrollable tabs */
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+}
+
+.nav-link-spacing {
+  display: inline-flex;
+  align-items: center;
+}

--- a/src/styles/components/tabs.scss
+++ b/src/styles/components/tabs.scss
@@ -8,11 +8,15 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    color: var(--bs-link-color);
 
-  &:hover {
-    cursor: pointer;
-  }
+    &:hover {
+      cursor: pointer;
+    }
 
+    &.active {
+      color: var(--bs-link-color) !important;
+    }
 }
 
 .panel-tabs-flex-wrapper {
@@ -22,7 +26,13 @@
   white-space: nowrap;
 }
 
-.nav-link-spacing {
+.nav-spacing {
+  display: inline;
+  margin-right: 0;
+  margin-left: 0;
+}
+
+.nav-item-spacing {
   display: inline-flex;
   align-items: center;
 }

--- a/src/styles/components/tabs.scss
+++ b/src/styles/components/tabs.scss
@@ -1,38 +1,43 @@
-.panel-tab-container {
+@mixin navLinkStyles {
   display: flex;
   align-items: center; /* Align items vertically */
+  max-width: 20ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--bs-link-color);
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &.active {
+    color: var(--bs-link-color) !important;
+    background-color: var(--white) !important;
+  }
 }
 
-.panel-tab {
-    max-width: 20ch;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: var(--bs-link-color);
-
-    &:hover {
-      cursor: pointer;
-    }
-
-    &.active {
-      color: var(--bs-link-color) !important;
-    }
-}
-
-.panel-tabs-flex-wrapper {
+.card-header-tabs, .nav-tabs {
+  margin-right: 0;
+  margin-left: 0;
   /* Ensures horizontally scrollable tabs */
   overflow-x: auto;
   overflow-y: hidden;
   white-space: nowrap;
+
+  > .nav-item {
+    display: inline-flex;
+    align-items: center;
+
+    > .nav-link {
+      @include navLinkStyles;
+    }
+  }
+
+  > .nav-link > a > div > span {
+     @include navLinkStyles;
+  }
 }
 
-.nav-spacing {
-  display: inline;
-  margin-right: 0;
-  margin-left: 0;
-}
 
-.nav-item-spacing {
-  display: inline-flex;
-  align-items: center;
-}
+

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -7,6 +7,7 @@
 @use './components/alert';
 @use './components/button.scss';
 @use './components/form';
+@use './components/tabs';
 
 // Import default bootstrap styles
 @import 'bootstrap/dist/css/bootstrap.min.css';


### PR DESCRIPTION
Create generic styling for the tabs: 

- Implementation in the styling in asab_webui_shell 
- Do not break any custom styling of the tabs in library/configuration/elsewhere
- Unify cursor events, background color on active tabs etc. 

This pull request is related to the merge request on Gitlab.