### PR TITLE
Make the collapsible entry in the sidebar bold.

### DIFF
--- a/src/containers/Sidebar/sidebar.scss
+++ b/src/containers/Sidebar/sidebar.scss
@@ -61,6 +61,8 @@ $sidebar-transition-timing-function: cubic-bezier(0.6, 0.6, 0, 1);
 	}
 
 	.sidebar-collapsible {
+		font-weight: bold;
+
 		transition: transform 0.1s $sidebar-transition-timing-function;
 		&:hover {
 			span .bi-chevron-down {


### PR DESCRIPTION
Basically a proposal - it should help users to navigate the sidebar:

<img width="499" height="614" alt="image" src="https://github.com/user-attachments/assets/431d99ef-81ff-4132-b3b1-ae177ada7af2" />

<img width="175" height="938" alt="image" src="https://github.com/user-attachments/assets/b5951ba3-93e1-4864-bacc-b460f28684f5" />


"Bold" font face is aligned with DataTable2 header style, so it doesn't introduce another font styling.
Looks coherent to me.
