### PR TITLE
Informational screens: fixing responsivity bug for small height screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Shell
 
+## 26.3.2
+
+- Fix for informational screens with illustrations where layout was broken on screens with small height (#35)
+
 ## 26.3.1
 
 - Implemented `hasSidebar` configuration option, implemented `hasHeaderTitle` configuration option, removed support for meta tags of header images in dynamic configuration (#8)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_shell",
-	"version": "26.3.1",
+	"version": "26.3.2",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Shell Application",
 	"contributors": [

--- a/src/screens/InvalidRouteScreen.js
+++ b/src/screens/InvalidRouteScreen.js
@@ -13,7 +13,7 @@ export default function InvalidRouteScreen(props) {
 	const { t } = useTranslation();
 
 	return(
-		<Container className="invalid-route-container h-100" fluid>
+		<Container className="invalid-route-container h-100">
 			<Card className="invalid-route-card">
 				<CardBody className="text-center invalid-route-cardbody">
 					<Row className="justify-content-center">

--- a/src/screens/InvalidRouteScreen.js
+++ b/src/screens/InvalidRouteScreen.js
@@ -18,7 +18,7 @@ export default function InvalidRouteScreen(props) {
 				<CardBody className="text-center invalid-route-cardbody">
 					<Row className="justify-content-center">
 						<Col>
-							<div className='h-75'>
+							<div className='invalid-route-img-container'>
 								<FlowbiteIllustration name="error" className="pb-4" title={t("InvalidRouteScreen|Nothing here")}/>
 							</div>
 							<p className="card-text">{t("InvalidRouteScreen|Sorry, we can't find the page you are looking for.")}</p>

--- a/src/screens/InvalidRouteScreen.scss
+++ b/src/screens/InvalidRouteScreen.scss
@@ -1,5 +1,5 @@
 .invalid-route-container {
-	overflow-y: auto;
+	overflow: hidden;
 }
 
 .invalid-route-card {
@@ -9,7 +9,6 @@
 	top: 50%;
 	left: 50%;
 	transform: translate(-50%, -50%);
-	// margin: 4rem auto 0;
 	border: 1px solid var(--bs-primary);
 }
 
@@ -18,4 +17,10 @@
 	align-items: center; /* Vertically center */
 	justify-content: center; /* Horizontally center */
 	overflow: hidden;
+	margin: 1rem;
+}
+
+.invalid-route-img-container{
+	height: 75%;
+	max-height: 60vh;
 }

--- a/src/screens/InvalidRouteScreen.scss
+++ b/src/screens/InvalidRouteScreen.scss
@@ -1,5 +1,5 @@
 .invalid-route-container {
-	overflow: hidden;
+	overflow-y: auto;
 }
 
 .invalid-route-card {
@@ -9,6 +9,7 @@
 	top: 50%;
 	left: 50%;
 	transform: translate(-50%, -50%);
+	// margin: 4rem auto 0;
 	border: 1px solid var(--bs-primary);
 }
 
@@ -16,4 +17,5 @@
 	display: flex;
 	align-items: center; /* Vertically center */
 	justify-content: center; /* Horizontally center */
+	overflow: hidden;
 }

--- a/src/screens/UnauthorizedAccessScreen.js
+++ b/src/screens/UnauthorizedAccessScreen.js
@@ -54,12 +54,12 @@ export default function UnauthorizedAccessScreen(props) {
 
 	// Else return the Not authorized screen
 	return(
-		<Container className="unauthorized-container h-100" fluid>
+		<Container className="unauthorized-container h-100">
 			<Card className="unauthorized-card">
 				<CardBody className="text-center unauthorized-cardbody">
 					<Row className="justify-content-center">
 						<Col>
-							<div className="w-50 mx-auto">
+							<div className="unauthorized-img-container">
 								<FlowbiteIllustration name="unauthorized" className="pb-4" title={t("UnauthorizedAccessScreen|Unauthorized access")}/>
 							</div>
 							{props.resource ?

--- a/src/screens/UnauthorizedAccessScreen.scss
+++ b/src/screens/UnauthorizedAccessScreen.scss
@@ -16,4 +16,11 @@
 	display: flex;
 	align-items: center; /* Vertically center */
 	justify-content: center; /* Horizontally center */
+	overflow: hidden;
+	margin: 1rem;
+}
+
+.unauthorized-img-container{
+	height: 75%;
+	max-height: 50vh;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled vertical scrolling on the invalid route page to prevent content from being cut off.
  * Ensured content within the error card does not overflow its bounds.

* **Style**
  * Switched the invalid route page to a fixed-width layout for improved readability and consistency across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->