### PR TITLE
Fix on serialization of bigint values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Shell
 
+## 27.3.10
+
+- Fix on BigInt serialization with JSON.stringify (#58)
+
 ## 27.3.9
 
 - Refactor BigInt JSON parsing method for BigInt values that it can handle also array of BigInt numbers. (#57)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_shell",
-	"version": "27.3.9",
+	"version": "27.3.10",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Shell Application",
 	"contributors": [

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -79,10 +79,11 @@ class Application extends Component {
 		// This is important to preserve 64bit numbers from the server such as IP addresses, timestamps etc.
 		this.JSONParseBigInt = new Set(props?.bigint);
 
-		// Prevent JSON.stringify from throwing on BigInt values (including inside React's
-		// own dev-mode error handling).  BigInt has no native JSON representation so we
-		// serialize it as a decimal string.  This is set once here so all call sites in
-		// the app (user code, React internals, third-party libs) are covered automatically.
+		/*
+			Prevent JSON.stringify from throwing on BigInt values (including inside React's
+			own dev-mode error handling). BigInt has no native JSON representation so it is
+			serialized as a decimal string.
+		*/
 		if (typeof BigInt !== "undefined" && typeof BigInt.prototype.toJSON !== "function") {
 			Object.defineProperty(BigInt.prototype, "toJSON", {
 				value() { return this.toString(); },

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -79,6 +79,19 @@ class Application extends Component {
 		// This is important to preserve 64bit numbers from the server such as IP addresses, timestamps etc.
 		this.JSONParseBigInt = new Set(props?.bigint);
 
+		// Prevent JSON.stringify from throwing on BigInt values (including inside React's
+		// own dev-mode error handling).  BigInt has no native JSON representation so we
+		// serialize it as a decimal string.  This is set once here so all call sites in
+		// the app (user code, React internals, third-party libs) are covered automatically.
+		if (typeof BigInt !== "undefined" && typeof BigInt.prototype.toJSON !== "function") {
+			Object.defineProperty(BigInt.prototype, "toJSON", {
+				value() { return this.toString(); },
+				enumerable: false,
+				configurable: true,
+				writable: true,
+			});
+		}
+
 		this._handleKeyUp = this._handleKeyUp.bind(this);
 		// Clear print-ready timeout handler
 		this._clearPrintReadyTimeout = this._clearPrintReadyTimeout.bind(this);


### PR DESCRIPTION
- Fix on serialization of bigint values when used in JSON.stringify. BigInt has no native JSON representation so it is serialized as a decimal string.
- Addition to this PR: https://github.com/TeskaLabs/asab-webui-shell-lib/pull/57
- In old code (before this PR: https://github.com/TeskaLabs/asab-webui-shell-lib/pull/57) arrays of bigint were never converted to bigint (the reviver silently skipped array elements), so no serialization issue existed. 

<img width="620" height="58" alt="Screenshot from 2026-03-06 18-11-27" src="https://github.com/user-attachments/assets/0fcf348a-86a3-43e4-a699-0c7587215b85" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue causing errors when serializing BigInt values so JSON operations (including dev-mode error handling) no longer fail.
* **Documentation**
  * Added a changelog entry for version 27.3.10 describing the BigInt serialization fix.
* **Chores**
  * Bumped package version to 27.3.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->