### PR TITLE
Unify InvitationScreen with PasswordResetScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Shell
 
+## 27.3.12
+
+- Improve invitation UX (#61)
+
 ## 27.3.11
 
 - Temporaly pin the `axios` version within range of `1.8.4` to `1.14.0` included (#62)

--- a/src/modules/auth/header.js
+++ b/src/modules/auth/header.js
@@ -68,7 +68,7 @@ export function AuthHeaderDropdown(props) {
 				{displayInvite && (
 					<>
 						<DropdownItem divider />
-						<DropdownItem tag={Link} to='/auth/invite'>
+						<DropdownItem tag={Link} to='/auth/invite' state={{ clearInvitation: true }}>
 							{t('AuthHeader|Invite other users')}
 						</DropdownItem>
 						<DropdownItem divider />

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -48,73 +48,73 @@ export default function InvitationScreen(props) {
 	}
 
 	if (responseData) {
-		const emailSent = responseData.email_sent?.result === 'OK';
-		const emailError = responseData.email_sent?.error;
-		const registrationUrl = responseData.registration_url;
-		const credentialsId = responseData.credentials_id;
-		
-		if (responseData.result === 'OK') {
+		if (responseData.result !== 'OK') {
+			const responseError = responseData.error;
 			return (
-				<ResultCard status={emailSent ? 'success' : 'warning'}>
-					<h5 className='mb-3'>{t('InvitationScreen|Invitation was created successfully')}</h5>
-					{emailSent
-						? <p>{t('InvitationScreen|The user will receive an email with registration link.')}</p>
-						: <p>{t(
-							'InvitationScreen|However, it was not possible to send the invitation to the user via email ({{reason}}).',
-							{ reason: t(emailError) },
-						)}</p>
-					}
-					{registrationUrl
-						&& <>
-							{emailSent
-								? <p>{t('InvitationScreen|You can also share the link manually:')}</p>
-								: <p>{t('InvitationScreen|You can share the link manually:')}</p>
-							}
-							<div>
-								<CopyableInput
-									className='mt-2 mb-3'
-									value={registrationUrl}
-								/>
-							</div>
-						</>
+				<ResultCard status='danger'>
+					<h5>{t('InvitationScreen|Invitation request failed')}</h5>
+					{responseError
+						&& <p>{t(responseError)}</p>
 					}
 					<div className='mt-2'>
-						{(canAccessCredentialsDetail && credentialsId)
-							? <Button
-								onClick={() => navigate(`/auth/credentials/${credentialsId}`)}
-								color='primary'
-								size='lg'
-							>
-								{t('InvitationScreen|Continue to credentials detail')}
-							</Button>
-							: <Button
-								onClick={() => navigate('/')}
-								color='primary'
-								size='lg'
-							>
-								{t('General|Continue')}
-							</Button>
-						}
+						<Button
+							onClick={() => setResponseData(undefined)}
+							color='primary'
+							size='lg'
+						>
+							{t('General|Back')}
+						</Button>
 					</div>
 				</ResultCard>
 			);
 		}
 
-		const responseError = responseData.error;
+		const emailSent = responseData.email_sent?.result === 'OK';
+		const emailError = responseData.email_sent?.error;
+		const registrationUrl = responseData.registration_url;
+		const credentialsId = responseData.credentials_id;
+		
 		return (
-			<ResultCard status='danger'>
-				<h5>{t('InvitationScreen|Invitation request failed')}</h5>
-				{responseError
-					&& <p>{t(responseError)}</p>
+			<ResultCard status={emailSent ? 'success' : 'warning'}>
+				<h5 className='mb-3'>{t('InvitationScreen|Invitation was created successfully')}</h5>
+				{emailSent
+					? <p>{t('InvitationScreen|The user will receive an email with registration link.')}</p>
+					: <p>{t(
+						'InvitationScreen|However, it was not possible to send the invitation to the user via email ({{reason}}).',
+						{ reason: t(emailError) },
+					)}</p>
+				}
+				{registrationUrl
+					&& <>
+						{emailSent
+							? <p>{t('InvitationScreen|You can also share the link manually:')}</p>
+							: <p>{t('InvitationScreen|You can share the link manually:')}</p>
+						}
+						<div>
+							<CopyableInput
+								className='mt-2 mb-3'
+								value={registrationUrl}
+							/>
+						</div>
+					</>
 				}
 				<div className='mt-2'>
-					<Button
-						onClick={() => setResponseData(undefined)}
-						color='primary'
-						size='lg'
-					>
-						{t('General|Back')}
-					</Button>
+					{(canAccessCredentialsDetail && credentialsId)
+						? <Button
+							onClick={() => navigate(`/auth/credentials/${credentialsId}`)}
+							color='primary'
+							size='lg'
+						>
+							{t('InvitationScreen|Continue to credentials detail')}
+						</Button>
+						: <Button
+							onClick={() => navigate('/')}
+							color='primary'
+							size='lg'
+						>
+							{t('General|Continue')}
+						</Button>
+					}
 				</div>
 			</ResultCard>
 		);

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -83,7 +83,7 @@ export default function InvitationScreen(props) {
 		}
 
 		const emailSent = responseData.email_sent?.result === 'OK';
-		const emailError = responseData.email_sent?.error;
+		const emailError = responseData.email_sent?.error || 'InvitationScreen|Unknown error';
 		const registrationUrl = responseData.registration_url;
 		const credentialsId = responseData.credentials_id;
 		

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -24,7 +24,6 @@ export default function InvitationScreen(props) {
 
 	// Handle email input change
 	const handleEmailChange = (e) => {
-		e.preventDefault();
 		setEmailValue(e.target.value);
 	}
 

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -41,6 +41,7 @@ export default function InvitationScreen(props) {
 	// Send invitation to the specified email
 	const sendInvitation = async (e) => {
 		e.preventDefault();
+		if (isSubmitting) return;
 		setIsSubmitting(true);
 		const body = {
 			email: emailValue
@@ -49,14 +50,14 @@ export default function InvitationScreen(props) {
 			const response = await SeaCatAuthAPI.post(`/account/${tenant}/invite`, body)
 			setResponseData(response?.data);
 			setEmailValue('');
-			setIsSubmitting(false);
 		} catch(e) {
-			setIsSubmitting(false);
 			if (e?.response?.data) {
 				setResponseData(e?.response?.data);
 				return;
 			}
 			props.app.addAlertFromException(e, t('InvitationScreen|Failed to create invitation'));
+		} finally {
+			setIsSubmitting(false);
 		}
 	}
 

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ResultCard, useAppSelector } from 'asab_webui_components';
+import { ResultCard, useAppSelector, CopyableInput } from 'asab_webui_components';
 import { useNavigate } from 'react-router';
 
 import {
 	Container, Row, Col,
-	Button, Form, FormText,
+	Button, Form,
 	Card, CardBody, CardHeader, CardFooter,
 	InputGroup, InputGroupText, Input, Label
 } from 'reactstrap';
@@ -15,33 +15,11 @@ import { FlowbiteIllustration } from 'asab_webui_components';
 // Component that handles user invitation
 export default function InvitationScreen(props) {
 	const [emailValue, setEmailValue] = useState('');
-	const [isInvitationSuccessful, setIsInvitationSuccessful] = useState(undefined);
-	const [registrationUrl, setRegistrationUrl] = useState(undefined);
-	const [urlCopied, setUrlCopied] = useState(undefined);
+	const [responseData, setResponseData] = useState(undefined);
 	const tenant = useAppSelector(state => state.tenant?.current);
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
-
-	// Copy registration URL if there is any
-	const copyRegistrationUrl = () => {
-		if (!registrationUrl) {
-			console.error('No registration URL to copy.');
-			return
-		}
-
-		navigator.clipboard.writeText(registrationUrl)
-			.then(() => {
-				setUrlCopied(true);
-				let timeoutId = setTimeout(() => setUrlCopied(false), 3000);
-				return () => {
-					clearTimeout(timeoutId);
-				};
-			})
-			.catch((error) => {
-				console.error('Failed to copy registration URL: ', error);
-			});
-	};
 
 	// Validate email input
 	const emailValidation = (e) => {
@@ -57,161 +35,138 @@ export default function InvitationScreen(props) {
 		};
 		try {
 			let response = await SeaCatAuthAPI.post(`/account/${tenant}/invite`, body)
-			if (response?.data?.result !== 'OK') {
-				throw new Error('Invitation has not been sent');
-			}
-			setIsInvitationSuccessful(true);
+			setResponseData(response?.data);
 			setEmailValue('');
-			if (response?.data?.registration_url) {
-				setRegistrationUrl(response?.data?.registration_url);
-			} else {
-				setRegistrationUrl(undefined);
-			}
 		} catch(e) {
-			setIsInvitationSuccessful(false);
-			if (e?.response?.data?.registration_url) {
-				setRegistrationUrl(e?.response?.data?.registration_url);
+			if (e?.response?.data) {
+				setResponseData(e?.response?.data);
 			} else {
-				setRegistrationUrl(undefined);
+				props.app.addAlertFromException(e, t('InvitationScreen|Failed to create invitation'));
 			}
 		}
 	}
 
-	// Component that displays the registration URL with a copy button
-	const CopyableRegistrationUrl = ({ registrationUrl }) => (
-		<>
-			<FormText>
-				{t('InvitationScreen|If you want to invite the user manually, message them the registration URL below:')}
-			</FormText>
-			<InputGroup className='mt-2 mb-3'>
-				<Input 
-					readOnly
-					value={registrationUrl}
-				/>
-				<Button
-					outline
-					color='primary'
-					className='text-nowrap'
-					onClick={copyRegistrationUrl}
-				>
-					<i
-						className={urlCopied ? 'bi bi-clipboard-check pe-2' : 'bi bi-clipboard pe-2'}
-						title={t('InvitationScreen|Copy to clipboard')}
-					/>
-					{urlCopied
-						? t('InvitationScreen|Copied!')
-						: t('InvitationScreen|Copy URL')
+	if (responseData) {
+		const emailSent = responseData.email_sent?.result === 'OK';
+		const emailError = responseData.email_sent?.error;
+		const registrationUrl = responseData.registration_url;
+		
+		if (responseData.result === 'OK') {
+			return (
+				<ResultCard status={emailSent ? 'success' : 'warning'}>
+					<h5 className='mb-3'>{t('InvitationScreen|Invitation was created successfully')}</h5>
+					{emailSent
+						? <p>{t('InvitationScreen|The user will receive an email with registration link.')}</p>
+						: <p>{t(
+							'InvitationScreen|However, it was not possible to send the invitation to the user via email ({{reason}}).',
+							{ reason: t(emailError) },
+						)}</p>
 					}
-				</Button>
-			</InputGroup>
-		</>
-	);
+					{registrationUrl
+						&& <>
+							{emailSent
+								? <p>{t('InvitationScreen|You can also share the link manually:')}</p>
+								: <p>{t('InvitationScreen|You can share the link manually:')}</p>
+							}
+							<div>
+								<CopyableInput
+									className='mt-2 mb-3'
+									value={registrationUrl}
+								/>
+							</div>
+						</>
+					}
+					<div className='mt-2'>
+						<Button
+							onClick={() => navigate('/auth/credentials')}
+							color='primary'
+							size='lg'
+						>
+							{t('General|Continue')}
+						</Button>
+					</div>
+				</ResultCard>
+			);
+		}
 
-	// Display for successful invitation
-	const SuccessfulInvitationCardBody = () => (
-		<>
-			<h6>{t('InvitationScreen|Invitation was sent successfully')}</h6>
-			{registrationUrl && <CopyableRegistrationUrl
-				registrationUrl={registrationUrl}
-			/>}
-			<div className='mt-2'>
-				<Button
-					onClick={() => navigate('/auth/credentials')}
-					color='primary'
-					size='lg'
-				>
-					{t('General|Continue')}
-				</Button>
-			</div>
-		</>
-	);
-
-	// Display for unsuccessful invitation
-	const UnsuccessfulInvitationCardBody = () => (
-		<>
-			<h6>{t('InvitationScreen|Invitation was not sent')}</h6>
-			{registrationUrl
-				? <CopyableRegistrationUrl
-					registrationUrl={registrationUrl}
-				/>
-				: <FormText>{t('InvitationScreen|The user could not be invited')}</FormText>
-			}
-			<div className='mt-2'>
-				<Button
-					onClick={() => setIsInvitationSuccessful(undefined)}
-					color='primary'
-					size='lg'
-				>
-					{t('General|Back')}
-				</Button>
-			</div>
-		</>
-	);
+		const responseError = responseData.error;
+		return (
+			<ResultCard status='danger'>
+				<h5>{t('InvitationScreen|Invitation request failed')}</h5>
+				{responseError
+					&& <p>{t(responseError)}</p>
+				}
+				<div className='mt-2'>
+					<Button
+						onClick={() => setResponseData(undefined)}
+						color='primary'
+						size='lg'
+					>
+						{t('General|Back')}
+					</Button>
+				</div>
+			</ResultCard>
+		);
+	}
 
 	return (
-		<Container fluid className={(isInvitationSuccessful == undefined) ? '' : 'h-100'}>
-			{(isInvitationSuccessful != undefined) ? (
-				<ResultCard status={isInvitationSuccessful ? 'success' : 'danger'}>
-					{isInvitationSuccessful ? <SuccessfulInvitationCardBody/> : <UnsuccessfulInvitationCardBody/>}
-				</ResultCard>
-			) : (
-				<Row className='justify-content-center pt-5'>
-					<Col md='4'>
-						<Form onSubmit={(e) => {sendInvitation(e)}}>
-							<Card className='invite-card'>
-								<CardHeader className='card-header-flex'>
-									<div className='flex-fill'>
-										<h3>
-											<i className='bi bi-person-plus pe-2' />
-											{t('InvitationScreen|Invite other user')}
-										</h3>
-									</div>
-								</CardHeader>
-								<CardBody>
-									<div className="w-50 mx-auto">
-										<FlowbiteIllustration
-											name='invite'
-											className='pb-3'
-											title={t('InvitationScreen|Invite other user')}
-										/>
-									</div>
-									<Label>{t('InvitationScreen|Enter the user\'s email address')}</Label>
-									<InputGroup>
-										<InputGroupText>
-											<i className='bi bi-envelope-at' />
-										</InputGroupText>
-										<Input
-											name='email'
-											type='email'
-											autoComplete='email'
-											autoFocus={true}
-											value={emailValue}
-											onChange={(e) => {emailValidation(e)}}
-										/>
-									</InputGroup>
-								</CardBody>
-								<CardFooter className='card-footer-flex'>
-									<Button
-										outline
-										color='primary'
-										type='button'
-										onClick={() => navigate(-1)}
-									>
-										{t('General|Cancel')}
-									</Button>
-									<div className='flex-fill'>&nbsp;</div>
-									<Button
-										color='primary'
-										disabled={emailValue === ''} // Disable button if input is empty
-									>
-										{t('InvitationScreen|Invite')}
-									</Button>
-								</CardFooter>
-							</Card>
-						</Form>
-					</Col>
-				</Row>
-			)}
+		<Container fluid>
+			<Row className='justify-content-center pt-5'>
+				<Col md='4'>
+					<Form onSubmit={(e) => {sendInvitation(e)}}>
+						<Card className='invite-card'>
+							<CardHeader className='card-header-flex'>
+								<div className='flex-fill'>
+									<h3>
+										<i className='bi bi-person-plus pe-2' />
+										{t('InvitationScreen|Invite other user')}
+									</h3>
+								</div>
+							</CardHeader>
+							<CardBody>
+								<div className="w-50 mx-auto">
+									<FlowbiteIllustration
+										name='invite'
+										className='pb-3'
+										title={t('InvitationScreen|Invite other user')}
+									/>
+								</div>
+								<Label>{t('InvitationScreen|Enter the user\'s email address')}</Label>
+								<InputGroup>
+									<InputGroupText>
+										<i className='bi bi-envelope-at' />
+									</InputGroupText>
+									<Input
+										name='email'
+										type='email'
+										autoComplete='email'
+										autoFocus={true}
+										value={emailValue}
+										onChange={(e) => {emailValidation(e)}}
+									/>
+								</InputGroup>
+							</CardBody>
+							<CardFooter className='card-footer-flex'>
+								<Button
+									outline
+									color='primary'
+									type='button'
+									onClick={() => navigate(-1)}
+								>
+									{t('General|Cancel')}
+								</Button>
+								<div className='flex-fill'>&nbsp;</div>
+								<Button
+									color='primary'
+									disabled={emailValue === ''} // Disable button if input is empty
+								>
+									{t('InvitationScreen|Invite')}
+								</Button>
+							</CardFooter>
+						</Card>
+					</Form>
+				</Col>
+			</Row>
 		</Container>
 	);
 }

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
+import { useNavigate, Link } from 'react-router';
 
 import {
 	Container, Row, Col,
@@ -101,16 +101,17 @@ export default function InvitationScreen(props) {
 						</div>
 					</>
 				}
-				<div className='mt-2'>
-					{(canAccessCredentialsDetail && credentialsId)
-						? <Button
-							onClick={() => navigate(`/auth/credentials/${credentialsId}`)}
-							color='primary'
-							size='lg'
+				{(canAccessCredentialsDetail && credentialsId)
+					&& <div className='mt-2 mb-3'>
+						<Link
+							to={`/auth/credentials/${credentialsId}`}
 						>
-							{t('InvitationScreen|Continue to credentials detail')}
-						</Button>
-						: <Button
+							{t('InvitationScreen|Go to credentials detail')}
+						</Link>
+					</div>
+				}
+				<div className='mt-2'>
+					<Button
 						onClick={() => navigate('/')}
 						color='primary'
 						size='lg'

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, Link } from 'react-router';
+import { useNavigate, Link, useLocation } from 'react-router';
 
 import {
 	Container, Row, Col,
@@ -22,6 +22,16 @@ export default function InvitationScreen(props) {
 	const navigate = useNavigate();
 	const SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
 	const canAccessCredentialsDetail = isAuthorized(['seacat:credentials:access'], props.app);
+	const location = useLocation();
+
+	useEffect(() => {
+		if (location?.state?.clearInvitation === true) {
+			// Clear the invitation data to show the form again
+			setResponseData(undefined);
+			setEmailValue('');
+			navigate('.', { replace: true, state: {} });
+		}
+	}, [location?.state?.clearInvitation]);
 
 	// Handle email input change
 	const handleEmailChange = (e) => {

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ResultCard, useAppSelector, CopyableInput } from 'asab_webui_components';
 import { useNavigate } from 'react-router';
 
 import {
@@ -10,7 +9,8 @@ import {
 	InputGroup, InputGroupText, Input, Label
 } from 'reactstrap';
 
-import { FlowbiteIllustration } from 'asab_webui_components';
+import { ResultCard, useAppSelector, CopyableInput, FlowbiteIllustration } from 'asab_webui_components';
+import { isAuthorized } from 'asab_webui_components/seacat-auth';
 
 // Component that handles user invitation
 export default function InvitationScreen(props) {
@@ -20,6 +20,7 @@ export default function InvitationScreen(props) {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
+	const canAccessCredentialsDetail = isAuthorized(['seacat:credentials:access'], props.app);
 
 	// Handle email input change
 	const handleEmailChange = (e) => {
@@ -50,6 +51,7 @@ export default function InvitationScreen(props) {
 		const emailSent = responseData.email_sent?.result === 'OK';
 		const emailError = responseData.email_sent?.error;
 		const registrationUrl = responseData.registration_url;
+		const credentialsId = responseData.credentials_id;
 		
 		if (responseData.result === 'OK') {
 			return (
@@ -77,13 +79,22 @@ export default function InvitationScreen(props) {
 						</>
 					}
 					<div className='mt-2'>
-						<Button
-							onClick={() => navigate('/auth/credentials')}
-							color='primary'
-							size='lg'
-						>
-							{t('General|Continue')}
-						</Button>
+						{(canAccessCredentialsDetail && credentialsId)
+							? <Button
+								onClick={() => navigate(`/auth/credentials/${credentialsId}`)}
+								color='primary'
+								size='lg'
+							>
+								{t('InvitationScreen|Continue to credentials detail')}
+							</Button>
+							: <Button
+								onClick={() => navigate('/')}
+								color='primary'
+								size='lg'
+							>
+								{t('General|Continue')}
+							</Button>
+						}
 					</div>
 				</ResultCard>
 			);

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -122,7 +122,7 @@ export default function InvitationScreen(props) {
 				}
 				<div className='mt-2'>
 					<Button
-						onClick={() => navigate('/')}
+						onClick={() => navigate(-1)}
 						color='primary'
 						size='lg'
 					>

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -34,15 +34,15 @@ export default function InvitationScreen(props) {
 			email: emailValue
 		};
 		try {
-			let response = await SeaCatAuthAPI.post(`/account/${tenant}/invite`, body)
+			const response = await SeaCatAuthAPI.post(`/account/${tenant}/invite`, body)
 			setResponseData(response?.data);
 			setEmailValue('');
 		} catch(e) {
 			if (e?.response?.data) {
 				setResponseData(e?.response?.data);
-			} else {
-				props.app.addAlertFromException(e, t('InvitationScreen|Failed to create invitation'));
+				return;
 			}
+			props.app.addAlertFromException(e, t('InvitationScreen|Failed to create invitation'));
 		}
 	}
 

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -26,10 +26,10 @@ export default function InvitationScreen(props) {
 
 	useEffect(() => {
 		if (location?.state?.clearInvitation === true) {
-			// Clear the invitation data to show the form again
+			// Clear the invitation data and reload the page without the parameter to ensure showing an empty form again
 			setResponseData(undefined);
 			setEmailValue('');
-			navigate('.', { replace: true, state: {} });
+			navigate(location.pathname, { replace: true, state: {} });
 		}
 	}, [location?.state?.clearInvitation]);
 

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -21,8 +21,8 @@ export default function InvitationScreen(props) {
 	const navigate = useNavigate();
 	const SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
 
-	// Validate email input
-	const emailValidation = (e) => {
+	// Handle email input change
+	const handleEmailChange = (e) => {
 		e.preventDefault();
 		setEmailValue(e.target.value);
 	}
@@ -113,7 +113,7 @@ export default function InvitationScreen(props) {
 		<Container fluid>
 			<Row className='justify-content-center pt-5'>
 				<Col md='4'>
-					<Form onSubmit={(e) => {sendInvitation(e)}}>
+					<Form onSubmit={sendInvitation}>
 						<Card className='invite-card'>
 							<CardHeader className='card-header-flex'>
 								<div className='flex-fill'>
@@ -142,7 +142,7 @@ export default function InvitationScreen(props) {
 										autoComplete='email'
 										autoFocus={true}
 										value={emailValue}
-										onChange={(e) => {emailValidation(e)}}
+										onChange={handleEmailChange}
 									/>
 								</InputGroup>
 							</CardBody>

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -16,6 +16,7 @@ import { isAuthorized } from 'asab_webui_components/seacat-auth';
 export default function InvitationScreen(props) {
 	const [emailValue, setEmailValue] = useState('');
 	const [responseData, setResponseData] = useState(undefined);
+	const [isSubmitting, setIsSubmitting] = useState(false);
 	const tenant = useAppSelector(state => state.tenant?.current);
 	const { t } = useTranslation();
 	const navigate = useNavigate();
@@ -30,6 +31,7 @@ export default function InvitationScreen(props) {
 	// Send invitation to the specified email
 	const sendInvitation = async (e) => {
 		e.preventDefault();
+		setIsSubmitting(true);
 		const body = {
 			email: emailValue
 		};
@@ -37,7 +39,9 @@ export default function InvitationScreen(props) {
 			const response = await SeaCatAuthAPI.post(`/account/${tenant}/invite`, body)
 			setResponseData(response?.data);
 			setEmailValue('');
+			setIsSubmitting(false);
 		} catch(e) {
+			setIsSubmitting(false);
 			if (e?.response?.data) {
 				setResponseData(e?.response?.data);
 				return;
@@ -107,13 +111,12 @@ export default function InvitationScreen(props) {
 							{t('InvitationScreen|Continue to credentials detail')}
 						</Button>
 						: <Button
-							onClick={() => navigate('/')}
-							color='primary'
-							size='lg'
-						>
-							{t('General|Continue')}
-						</Button>
-					}
+						onClick={() => navigate('/')}
+						color='primary'
+						size='lg'
+					>
+						{t('General|Continue')}
+					</Button>
 				</div>
 			</ResultCard>
 		);
@@ -168,7 +171,7 @@ export default function InvitationScreen(props) {
 								<div className='flex-fill'>&nbsp;</div>
 								<Button
 									color='primary'
-									disabled={emailValue === ''} // Disable button if input is empty
+									disabled={emailValue === '' || isSubmitting} // Disable button if input is empty or request is in flight
 								>
 									{t('InvitationScreen|Invite')}
 								</Button>

--- a/src/modules/invite/InvitationScreen.js
+++ b/src/modules/invite/InvitationScreen.js
@@ -25,12 +25,13 @@ export default function InvitationScreen(props) {
 	const location = useLocation();
 
 	useEffect(() => {
-		if (location?.state?.clearInvitation === true) {
-			// Clear the invitation data and reload the page without the parameter to ensure showing an empty form again
-			setResponseData(undefined);
-			setEmailValue('');
-			navigate(location.pathname, { replace: true, state: {} });
+		if (location?.state?.clearInvitation !== true) {
+			return;
 		}
+		// Clear the invitation data and reload the page without the parameter to ensure showing an empty form again
+		setResponseData(undefined);
+		setEmailValue('');
+		navigate(location.pathname, { replace: true, state: {} });
 	}, [location?.state?.clearInvitation]);
 
 	// Handle email input change


### PR DESCRIPTION
- depends on https://github.com/TeskaLabs/seacat-auth/pull/561
- requires i18n updates in federating apps (lmio-webui etc.)

# Summary
- Similarly to password reset, the invitation request can have a multi-result: one part is creating the invitation and the other is sending the invitation via email. There are three possible outcomes: invitation created and sent, invitation created but not sent and invitation not created. These correspond to three modes respectively: success, warning and error.

- Added link to created credentials detail (if authorized).
- The `Continue` button navigates to the previous page instead of credentials list.
- Clicking the `Invite other user` in the header opens an empty invitation even when currently on the invitation page.
- Added `isSubmitting` state to prevent duplicate submissions.

# Preview

Successful result card. The admin is authorized for viewing credentials detail but not for viewing the invitation link:

<img width="675" height="309" alt="image" src="https://github.com/user-attachments/assets/2eeea692-3c89-48a5-9c81-10f958cc7307" />

Success with exception. Invitation created but not sent because the email service is disabled:

<img width="665" height="424" alt="image" src="https://github.com/user-attachments/assets/f96bc3a4-467d-43b5-87c9-ad55d3f52b84" />

Failure. Email service is configured but unreachable. Cannot disclose invitation link:

<img width="661" height="250" alt="image" src="https://github.com/user-attachments/assets/d6c9691d-582e-434d-81b1-5fc5b46b9b82" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified invitation results into a single result view; form is disabled while submitting and clears the email on success.

* **New Features**
  * Shows a copyable registration URL when present and detailed email-delivery status/messages.
  * “Continue” returns to the previous page; a credential-details link appears when available and authorized.

* **Bug Fixes**
  * Opening Invite from the header clears prior invite state so users start fresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->