### PR TITLE
Introduce mw-medium css class

### DIFF
--- a/src/styles/constants/index.scss
+++ b/src/styles/constants/index.scss
@@ -72,3 +72,7 @@
 .cursor-pointer {
 	cursor: pointer;
 }
+
+.mw-medium {
+	max-width: 64rem;
+}


### PR DESCRIPTION
This is a shared class to use with Containers - applies max width 64rem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a new styling utility for medium-width constraints on page elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->