### PR TITLE
Refactor/change advanced view shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Shell
 
+## 27.4.4
+
+- Change advanced mode shortcut to CTRL+SHIFT+U, leave the alert visible for longer time (#72)
+
 ## 27.4.3
 
 - Fixed inconsistent usage of colors in button and alert components (#71)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_shell",
-	"version": "27.4.3",
+	"version": "27.4.4",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Shell Application",
 	"contributors": [

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -561,8 +561,12 @@ class Application extends Component {
 			this.setFullScreenMode('on');
 		}
 
-		// CTRL+M (Chrome, Firefox and Safari on Windows, Linux and MacOS)
-		if ((event.ctrlKey && event.code === 'KeyM')) {
+		// TODO: Remove CTRL+Q and CTRL+1 by May of 2027
+		// CTRL+SHIFT+U (Chrome, Firefox and Safari on Windows, Linux and MacOS)
+		// CTRL+Q (Windows) or CTRL+1 (Linux) enables the advanced mode
+		if ((event.ctrlKey && event.code === 'KeyQ') ||
+			(event.code === 'Digit1' && event.ctrlKey) ||
+			(event.ctrlKey && event.shiftKey && event.code === 'KeyU')) {
 			this.setAdvancedMode(0);
 		}
 
@@ -730,9 +734,9 @@ class Application extends Component {
 			enabled: enabled
 		});
 		if (enabled) {
-			this.addAlert('warning', "ASABApplicationContainer|Advanced mode enabled", 1, true);
+			this.addAlert('warning', "ASABApplicationContainer|Advanced mode enabled", 2, true);
 		} else {
-			this.addAlert('success', "ASABApplicationContainer|Advanced mode disabled", 1, true);
+			this.addAlert('success', "ASABApplicationContainer|Advanced mode disabled", 2, true);
 		}
 	}
 

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -561,8 +561,8 @@ class Application extends Component {
 			this.setFullScreenMode('on');
 		}
 
-		// CTRL+Q (Windows) or CTRL+1 (Linux) enables the advanced mode
-		if ((event.ctrlKey && event.code === 'KeyQ') || (event.code === 'Digit1' && event.ctrlKey)) {
+		// CTRL+M (Chrome, Firefox and Safari on Windows, Linux and MacOS)
+		if ((event.ctrlKey && event.code === 'KeyM')) {
 			this.setAdvancedMode(0);
 		}
 


### PR DESCRIPTION
Shortcut for advanced mode change to CTRL+SHIFT+U (safe on Chrome, Firefox, Safari on Windows, Linux and Mac). Keep the old CTRL+Q and CTRL+1 for now and remove those in May of 2027.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CTRL+SHIFT+U keyboard shortcut for toggling advanced mode.

* **Bug Fixes**
  * Adjusted alert notification duration behavior when switching between advanced and standard modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TeskaLabs/asab-webui-shell-lib/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->