### PR TITLE
Update WebSocket service to asab-lighthouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Shell
 
+## 27.4.6
+
+- Switch beacon WebSocket connection target from `asab-remote-control` to `asab-lighthouse`. (#74)
+
 ## 27.4.5
 
 - Change translation import from i18n locales (#73)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_shell",
-	"version": "27.5.5",
+	"version": "27.5.6",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Shell Application",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_shell",
-	"version": "27.4.5",
+	"version": "27.4.6",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Shell Application",
 	"contributors": [

--- a/src/modules/attentionrequired/service.jsx
+++ b/src/modules/attentionrequired/service.jsx
@@ -31,7 +31,7 @@ export default class AttentionRequiredService extends Service {
 			return;
 		}
 
-		const BeaconServiceClient = this.App.createWebSocket('asab-remote-control', `/beacon/${currentTenant}/ws`);
+		const BeaconServiceClient = this.App.createWebSocket('asab-lighthouse', `/beacon/${currentTenant}/ws`);
 		this.beaconWebSocket = BeaconServiceClient;
 
 		this.beaconWebSocket.onopen = () => {


### PR DESCRIPTION
switch beacon backend microservice websocket connects to: from `asab-remote-control` to `asab-lighthouse`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Beacon WebSocket connection to target the correct backend service, keeping the same connection path and preserving existing reconnection, parsing, and status behavior.

* **Chores**
  * Bumped the application version to **27.5.6**.
  * Added a changelog entry for this release noting the Beacon WebSocket target update (reference **`#74`**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->