### PR TITLE
Fix for userinfo with no tenant list + ability to specify custom Open ID Connect Client ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ASAB WebUI Shell
 
+## 27.5.3
+
+- Fix on userinfo with no tenants list + ability to specify custom Open ID Connect Client ID (#77)
+
 ## 27.5.2
 
 - Refactor media print styling for asab-pyppeteer (#76)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "asab_webui_shell",
-	"version": "27.5.2",
+	"version": "27.5.3",
 	"license": "BSD-3-Clause",
 	"description": "TeskaLabs ASAB WebUI Shell Application",
 	"contributors": [

--- a/src/modules/auth/api.js
+++ b/src/modules/auth/api.js
@@ -6,40 +6,31 @@ export class SeaCatAuthApi {
 	/*
 	SeaCat Auth Open ID Connect / OAuth2.0
 
-	From config.js:
-
-	module.exports = {
-		app: {
-			BASE_URL: 'http://localhost:3000',
-			API_PATH: 'api',
-			SERVICES: {openidconnect: 'openidconnect'},
-			...
+	From webpack.common.js:
 
 	To change a Client ID, set the SEACATAUTH environment variable in the webpack.common.js file:
 		const { DefinePlugin } = require('webpack');
 		...
 		new DefinePlugin({
-			'SEACATAUTH': JSON.stringify({
-				client_id: "my-app-webui"
-			})
+			'LOCAL_CONFIG': JSON.stringify({
+				"seacat.auth.scope": "openid tenant userinfo:*",
+				"seacat.auth.client_id": "llm-microlink-webui",
+			}),
 		})
 	*/
 
 	constructor(app) {
 		this.App = app;
 
-		const scope = this.App.Config.get('seacat.auth.scope');
-		this.Scope = scope ? scope : "openid tenant userinfo:* batman";
+		this.Scope = this.App.Config.get('seacat.auth.scope') || "openid tenant userinfo:* batman";
+
+		this.ClientId = this.App.Config.get('seacat.auth.client_id') || "asab-webui-auth";
+
+		// The console log is intentionally left here so that we can see the Client ID in the console
+		console.log('OpenID Connect Client ID:', this.ClientId);
 		
-		if (typeof SEACATAUTH !== 'undefined') {
-			this.ClientId = SEACATAUTH?.client_id || "asab-webui-auth";
-		} else {
-			this.ClientId = "asab-webui-auth";
-		}
 		this.SeaCatAuthAPI = this.App.axiosCreate('seacat-auth');
 		this.OidcAPI = this.App.axiosCreate('openidconnect');
-
-		console.log('OpenID Connect Client ID: ', this.ClientId);
 	}
 
 	// This method will cause a navigation from the app to the OAuth2 login screen

--- a/src/modules/auth/api.js
+++ b/src/modules/auth/api.js
@@ -6,7 +6,6 @@ export class SeaCatAuthApi {
 	/*
 	SeaCat Auth Open ID Connect / OAuth2.0
 
-
 	From config.js:
 
 	module.exports = {
@@ -15,6 +14,15 @@ export class SeaCatAuthApi {
 			API_PATH: 'api',
 			SERVICES: {openidconnect: 'openidconnect'},
 			...
+
+	To change a Client ID, set the SEACATAUTH environment variable in the webpack.common.js file:
+		const { DefinePlugin } = require('webpack');
+		...
+		new DefinePlugin({
+			'SEACATAUTH': JSON.stringify({
+				client_id: "my-app-webui"
+			})
+		})
 	*/
 
 	constructor(app) {
@@ -23,9 +31,15 @@ export class SeaCatAuthApi {
 		const scope = this.App.Config.get('seacat.auth.scope');
 		this.Scope = scope ? scope : "openid tenant userinfo:* batman";
 		
-		this.ClientId = "asab-webui-auth";
+		if (typeof SEACATAUTH !== 'undefined') {
+			this.ClientId = SEACATAUTH?.client_id || "asab-webui-auth";
+		} else {
+			this.ClientId = "asab-webui-auth";
+		}
 		this.SeaCatAuthAPI = this.App.axiosCreate('seacat-auth');
 		this.OidcAPI = this.App.axiosCreate('openidconnect');
+
+		console.log('OpenID Connect Client ID: ', this.ClientId);
 	}
 
 	// This method will cause a navigation from the app to the OAuth2 login screen

--- a/src/modules/auth/api.js
+++ b/src/modules/auth/api.js
@@ -8,7 +8,7 @@ export class SeaCatAuthApi {
 
 	From webpack.common.js:
 
-	To change a Client ID, set the SEACATAUTH environment variable in the webpack.common.js file:
+	To change a Client ID, set the seacat.auth.client_id configuration variable in the webpack.common.js file:
 		const { DefinePlugin } = require('webpack');
 		...
 		new DefinePlugin({

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -395,7 +395,7 @@ export default class AuthModule extends Module {
 		}
 
 		// Check for TenantService and pass tenants list obtained from userinfo resources
-		let availableTenants = Object.keys(this.UserInfo.resources).filter(tenant => tenant !== '*');
+		let availableTenants = Object.keys(this.UserInfo.resources ?? {}).filter(tenant => tenant !== '*');
 		if (this.UserInfo?.tenants == null) {
 			// This is a monkey patch to add the tenants list to the userinfo if missing
 			this.UserInfo['tenants'] = availableTenants;

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -322,6 +322,10 @@ export default class AuthModule extends Module {
 		if (this.UserInfo !== null) {
 			resources = this.UserInfo.resources ? this.UserInfo.resources[currentTenant] : [];
 			tenants = this.UserInfo.tenants ? this.UserInfo.tenants : [];
+			if (tenants == null || tenants.length === 0) {
+				// Fallback to tenant from resources if tenants list is not available
+				tenants = Object.keys(this.UserInfo.resources ?? {}).filter(tenant => tenant !== '*');
+			}
 		}
 		let valid = tenants ? tenants.indexOf(currentTenant) !== -1 : false;
 		// If user is superuser, then tenant access is granted
@@ -395,7 +399,11 @@ export default class AuthModule extends Module {
 		}
 
 		// Check for TenantService and pass tenants list obtained from userinfo resources
-		let availableTenants = Object.keys(this.UserInfo.resources ?? {}).filter(tenant => tenant !== '*');
+		let availableTenants = this.UserInfo.tenants;
+		if (availableTenants == null || availableTenants.length === 0) {
+			// Fallback to tenant from resources if tenants list is not available
+			availableTenants = Object.keys(this.UserInfo.resources ?? {}).filter(tenant => tenant !== '*');
+		}
 		if (this.UserInfo?.tenants == null) {
 			// This is a monkey patch to add the tenants list to the userinfo if missing
 			this.UserInfo['tenants'] = availableTenants;

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -394,10 +394,17 @@ export default class AuthModule extends Module {
 			this.App.AppStore.dispatch?.({ type: types.AUTH_USERINFO, payload: this.UserInfo });
 		}
 
-		/** Check for TenantService and pass tenants list obtained from userinfo */
-		let availableTenants = this.UserInfo.tenants;
+		// Check for TenantService and pass tenants list obtained from userinfo resources
+		let availableTenants = Object.keys(this.UserInfo.resources).filter(tenant => tenant !== '*');
+		if (this.UserInfo?.tenants == null) {
+			// This is a monkey patch to add the tenants list to the userinfo if missing
+			this.UserInfo['tenants'] = availableTenants;
+		}
 		if (this.App.Services.TenantService) {
-			await this.App.Services.TenantService.setTenants(availableTenants, this._getAuthorizedTenant(this.UserInfo));
+			await this.App.Services.TenantService.setTenants(
+				availableTenants,
+				this._getAuthorizedTenant(this.UserInfo)  // Get the authorized tenant
+			);
 		}
 
 		return true;

--- a/src/modules/tenant/TenantDropdown.js
+++ b/src/modules/tenant/TenantDropdown.js
@@ -1,37 +1,40 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { useAppSelector } from 'asab_webui_components';
 import { useTranslation } from 'react-i18next';
 
 import {
-	UncontrolledDropdown,
+	Dropdown,
 	DropdownItem,
-	DropdownMenu, 
+	DropdownMenu,
 	DropdownToggle,
 } from 'reactstrap';
 
 
 export default function TenantDropdown() {
 	const { t } = useTranslation();
+	const [isOpen, setIsOpen] = useState(false);
 	const current = useAppSelector(state => state?.tenant?.current);
 	const tenants = useAppSelector(state => state?.tenant?.tenants);
 
+	const toggle = () => setIsOpen(prev => !prev);
+
 	return (
-		<UncontrolledDropdown direction="down" title={t('tenant|Tenant')}>
+		<Dropdown isOpen={isOpen} toggle={toggle} direction="down" title={t('General|Tenant')}>
 			<DropdownToggle nav caret>
 				<i className="bi bi-house-lock pe-2"></i>
 				<TenantLabel tenant={current}/>
 			</DropdownToggle>
-			{ (tenants && tenants.length > 0) ?
-				<DropdownMenu className="shadow">
-					<DropdownItem header>Tenants</DropdownItem>
+			{isOpen && tenants?.length > 0 && (
+				<DropdownMenu className="shadow overflow-y-auto" style={{ maxHeight: '20em' }}>
+					<DropdownItem header>{t('General|Tenants')}</DropdownItem>
 					{tenants.map((tenant, i) => (
 						<DropdownItem key={i} tag="a" href={'?tenant='+tenant+'#/'}>
 							<TenantLabel tenant={tenant}/>
 						</DropdownItem>
 					))}
 				</DropdownMenu>
-			 : null}
-		</UncontrolledDropdown>
+			)}
+		</Dropdown>
 	);
 }
 


### PR DESCRIPTION
## Fix for userinfo with no tenant list

Product of the discussion with @byewokko - API Keys produce userinfo with no `tenants` fields but UI is still expecting this "somewhere". So this patch is introducing `tenants` array constructed from `resources` when `tenants` field is missing.

More correct solution is to find all places that uses `userinfo.tenants` array and switch them to `userinfo.resources` - so that we can drop `userinfo.tenants` completely.

## Ability to specify custom Open ID Connect Client ID

Also, I added an ability to specify different Open ID Connect Client ID in the webpack build file, so that the web application can override the default `asab-webui-auth` by its custom Client ID.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added build-time configuration support for the OAuth client ID, with a sensible default when not set.

* **Bug Fixes**
  * Improved tenant access resolution when user tenant details are missing by deriving available tenants from account resources (excluding the global wildcard).
  * Ensures the authorized tenant is consistently applied during user info provisioning and sign-in.

* **UI / Improvements**
  * Updated the tenant dropdown to a controlled experience with better rendering behavior and a capped menu height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->